### PR TITLE
fix: Add check for already applied patch and notify user accordingly

### DIFF
--- a/Win_1337_Patch/1337.cs
+++ b/Win_1337_Patch/1337.cs
@@ -179,6 +179,7 @@ namespace Win_1337_Patch
             }
             byte[] bexe = File.ReadAllBytes(exe);
             bool ok = true;
+            bool alreadyApplied = false;
             for (var i = 1; i < lines.Length; i += 1)
             {
                 if (lines[i].Trim() != "")
@@ -190,6 +191,12 @@ namespace Win_1337_Patch
                     byte f = byte.Parse(tmp2[0], System.Globalization.NumberStyles.HexNumber);
                     if (bexe[offsetHex] == byte.Parse(tmp2[0], System.Globalization.NumberStyles.HexNumber))
                         bexe[offsetHex] = byte.Parse(tmp2[1], System.Globalization.NumberStyles.HexNumber);
+                    else if (bexe[offsetHex] == byte.Parse(tmp2[1], System.Globalization.NumberStyles.HexNumber))
+                    {
+                        alreadyApplied = true;
+                        ok = false;
+                        break;
+                    }
                     else
                     {
                         MessageBox.Show("Offset [" + offsetHex.ToString("X") + "] Wrong...\n\nSet 0x" + bexe[offsetHex].ToString("X") + " -> I expected 0x" + byte.Parse(tmp2[0], System.Globalization.NumberStyles.HexNumber).ToString("X"), "Error...", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -214,6 +221,10 @@ namespace Win_1337_Patch
                 File.WriteAllBytes(exe, bexe);
                 SistemaPeCks(exe);
                 MessageBox.Show("File " + Path.GetFileName(exe) + " Patched...", "Info...", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            else if (alreadyApplied)
+            {
+                MessageBox.Show("The patch has already been applied.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/Win_1337_Patch/mCheckSum.cs
+++ b/Win_1337_Patch/mCheckSum.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 
 namespace Win_1337_Patch
 {
@@ -67,7 +68,8 @@ namespace Win_1337_Patch
                 {
                     Pein = uOriginal.ToString("X8");
                     Pefi = uRecalculated.ToString("X8");
-                    return true;
+                    MessageBox.Show("The patch has already been applied.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return true; // Indicate the patch was already applied
                 }
             }
             else


### PR DESCRIPTION
This update enhances the Win_1337_Patch namespace by adding a mechanism to check if a patch has already been applied to the target file. The following changes were made:

- Introduced a boolean `alreadyApplied` to track if the patch is already present.
- Modified the byte comparison logic to set `alreadyApplied` to true and break the loop if the patch is detected.
- Added a message box to notify the user if the patch has already been applied.
- Ensured that the appropriate error message is displayed without proceeding with the patching process if the patch is already applied.

These changes improve the user experience by preventing redundant patch applications and providing clear feedback.

Fixes #1 